### PR TITLE
added weight page

### DIFF
--- a/vet_calc_app/lib/main.dart
+++ b/vet_calc_app/lib/main.dart
@@ -435,7 +435,7 @@ class WeightFormState extends State<WeightForm> {
 
     return Scaffold(
         appBar: AppBar(
-          title: Text('Weight of $animal'),
+          title: Text('Weight of $animal  ($drug)'),
         ),
         body: Form(
           key: _formKey,


### PR DESCRIPTION
Added weight page after selecting drug from Cattle button. 
Currently opens up number keyboard on phone and only accepts numbers and '.' for calculations.
If user does not enter a number it will show an error telling them to enter a weight.
Currently no redirection to new CalculationPage but instead shows a snackbar saying "yay" if user enters a valid number and prints the animal, drug, and weight to the debug console.